### PR TITLE
Guard against NPE

### DIFF
--- a/src/rvoice/fluid_rvoice_event.c
+++ b/src/rvoice/fluid_rvoice_event.c
@@ -30,6 +30,9 @@ static int fluid_rvoice_eventhandler_push_LOCAL(fluid_rvoice_eventhandler_t *han
 static FLUID_INLINE void
 fluid_rvoice_event_dispatch(fluid_rvoice_event_t *event)
 {
+    if (!event || !event->method) {
+        return;
+    }
     event->method(event->object, event->param);
 }
 

--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -4069,6 +4069,9 @@ fluid_synth_render_blocks(fluid_synth_t *synth, int blockcount)
 
     fluid_check_fpe("??? Just starting up ???");
 
+    if (!synth || !synth->eventhandler) {
+        return 0;
+    }
     fluid_rvoice_eventhandler_dispatch_all(synth->eventhandler);
 
     /* do not render more blocks than we can store internally */


### PR DESCRIPTION
For some reason we're experiencing crashes in the fluid_rvoice_event_dispatch
This is our workaround for this issue. Do you have any idea what might be the reason? We're not doing anything fancy, just playing notes from one single soundfont.